### PR TITLE
Non-syllabic 'ed' suffix

### DIFF
--- a/lib/syllabize.rb
+++ b/lib/syllabize.rb
@@ -75,6 +75,7 @@ module Syllabize
     def handle_subtractions
       @syllables -= 1 if ends_in_silent_e?
       @syllables -= count_diphthongs if contains_diphthongs?
+      @syllables -= 1 if ends_in_non_syllablic_ed?
     end
 
     def count_vowels
@@ -113,6 +114,25 @@ module Syllabize
       str.end_with?('sm')
     end
 
+    def has_more_than_one_syllable?
+      (count_vowels - count_diphthongs) > 1
+    end
+
+    def ends_in_ed?
+      str.end_with?('ed')
+    end
+
+    def ending_ed_is_not_syllablic?
+      str.scan(/(t|d|tr|dr|tl|dl)ed\b/).empty?
+    end
+
+    def ends_in_non_syllablic_ed?
+      if has_more_than_one_syllable? && ends_in_ed? && ending_ed_is_not_syllablic?
+        true
+      else
+        false
+      end
+    end
 
     # for Ruby 1.9
     def __dir__

--- a/spec/lib/syllabize_spec.rb
+++ b/spec/lib/syllabize_spec.rb
@@ -157,6 +157,29 @@ describe Syllabize::Counter do
           expect(count).to eq(actual), "'#{word}' was not the correct number of syllables; expected #{actual}, was #{count}"
         end
       end
+
+      context 'with suffix /ed/' do
+        context '/ed/ is before /t/, /d/, /tr/, /tl/, /dr/, /dl/' do
+          it 'counts /ed/ as a syllable' do
+            expect(Syllabize::Counter.new('herded').count_syllables).to eq(2)
+            expect(Syllabize::Counter.new('carted').count_syllables).to eq(2)
+            expect(Syllabize::Counter.new('hundred').count_syllables).to eq(2)
+            expect(Syllabize::Counter.new('hatred').count_syllables).to eq(2)
+          end
+        end
+        context '/ed/ is before sounds unrelated to /t/ and /d/' do
+          it 'does not count /ed/ as a syllable' do
+            expect(Syllabize::Counter.new('worked').count_syllables).to eq(1)
+            expect(Syllabize::Counter.new('flapped').count_syllables).to eq(1)
+            expect(Syllabize::Counter.new('sneered').count_syllables).to eq(1)
+          end
+        end
+        context '/ed/ is the only syllable of a word' do
+          it 'it does count /ed/ as a syllable' do
+            expect(Syllabize::Counter.new('bed').count_syllables).to eq(1)
+          end
+        end
+      end
     end
     context 'other data' do
       it 'raises an error' do
@@ -169,5 +192,4 @@ describe Syllabize::Counter do
     subject { 'hello'.count_syllables }
     it { should == 2 }
   end
-
 end


### PR DESCRIPTION
Accounts for suffix 'ed' in words such as

worked, sneered, helped, tapped, mapped vs. hundred, bloodred, herded, carted

does not affect single syllable words such as 'bed'.
